### PR TITLE
- build correct file relation map to support ASM/ENT/EXT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Merlin32 extension will be documented in this file.
 
+###  0.4.0
+- labels that are included via ENT/EXT are now resolved across files
+
 ###  0.3.1
 - hover over decimal, hexadecimal or binary numbers shows the number in all three formats
 - local labels are now supported

--- a/extension.js
+++ b/extension.js
@@ -2811,7 +2811,7 @@ const asmlookups = {
                 "cycles": "7<sup>1<\/sup>"
             },
             {
-                "mode": "dpX",
+                "mode": "dp,X",
                 "hex": "95",
                 "info": "DP Indexed,X",
                 "c1": true,
@@ -4148,8 +4148,9 @@ var getAllLabelDefinitionsForWorkspace = function () {
                 //filter out ext labels
                 var filteredWorkspaceLabels = {};
                 for (var u in workspaceLabels) {
+                    filteredWorkspaceLabels[u] = {};
                     for (var label in workspaceLabels[u]) {
-                        if (!workspaceLabels[u]['isext']) {
+                        if (!workspaceLabels[u][label]['isext']) {
                             filteredWorkspaceLabels[u][label] = workspaceLabels[u][label];
                         }
                     }

--- a/extension.js
+++ b/extension.js
@@ -3940,7 +3940,6 @@ var poolRelationsRecursive = function (u, res, forcelinked) {
     if (fileRelations[u]) {
         for (var i in fileRelations[u]) {
             var df = fileRelations[u][i].uri;
-            //if(df === u) continue;
 
             found = false;
             for (var k in res) {

--- a/extension.js
+++ b/extension.js
@@ -3936,23 +3936,30 @@ var testAndAddFileRelation = function (document, splitted) {
     }
 }
 
-var poolRelationsRecursive = function(u, res)
-{
-    if(fileRelations[u]) {
-        for(var i in fileRelations[u]) {
+var poolRelationsRecursive = function (u, res, forcelinked) {
+    if (fileRelations[u]) {
+        for (var i in fileRelations[u]) {
             var df = fileRelations[u][i].uri;
             //if(df === u) continue;
 
             found = false;
-            for(var k in res) {
-                if(res[k].uri === df) {
+            for (var k in res) {
+                if (res[k].uri === df) {
                     found = true;
                     break;
                 }
             }
-            if(!found) {
-                res.push(fileRelations[u][i]);
-                poolRelationsRecursive(df, res);
+            if (!found) {
+                var obj = { uri: fileRelations[u][i].uri, linked: fileRelations[u][i].linked };
+                if (forcelinked) {
+                    obj.linked = true;
+                }
+                res.push(obj);
+                if (fileRelations[u][i].linked) {
+                    //once we encounter a linked relation, all further deeper connections are linked, too
+                    forcelinked = true;
+                }
+                poolRelationsRecursive(df, res, forcelinked);
             }
         }
     }
@@ -3960,11 +3967,10 @@ var poolRelationsRecursive = function(u, res)
     return res;
 }
 
-var poolRelations = function()
-{
+var poolRelations = function () {
     filepools = {};
-    for(var u in fileRelations) {
-        filepools[u] = poolRelationsRecursive(u, []);
+    for (var u in fileRelations) {
+        filepools[u] = poolRelationsRecursive(u, [], false);
     }
 }
 

--- a/extension.js
+++ b/extension.js
@@ -3397,7 +3397,7 @@ const linkcommands = [
 ];
 
 const includecommands = [
-    'put'
+    'asm', 'put'
 ];
 
 const findfilesglob = '**\/*.{s,asm,l}';
@@ -3787,7 +3787,8 @@ vscode.languages.registerRenameProvider('asm', {
 
 var allUris = [];
 var fileRelations = {}; //[uri] => [uri1, uri12, uri13, ...] lists of files that have a relationship with each other
-var workspaceLabels = {}; //[uri][labelname] => {'range': vscode.Range, 'document': vscode.TextDocument}
+var filepools = {};
+var workspaceLabels = {}; //[uri][labelname] => {'range': vscode.Range, 'document': vscode.TextDocument, 'isext': true|false, 'isent': true|false}
 var labelReferences = {}; //[uri] => [{},...]
 
 /* append a space if the string does not end with one */
@@ -3913,7 +3914,7 @@ var testAndAddFileRelation = function (document, splitted) {
 
     var u = document.uri.toString();
     if (!fileRelations[u]) {
-        fileRelations[u] = [u];
+        fileRelations[u] = [{ 'uri': u, 'linked': false }];
     }
 
     if (includecommands.includes(splitted.parts[1].toLowerCase())) {
@@ -3921,18 +3922,53 @@ var testAndAddFileRelation = function (document, splitted) {
         var u2 = vscode.Uri.joinPath(document.uri, '../' + splitted.parts[2]).toString();
         var u3 = vscode.Uri.joinPath(document.uri, '../' + splitted.parts[2] + '.s').toString();
         var ua;
+        var linked = (splitted.parts[1].toLowerCase() === 'asm');
         for (var i in allUris) {
             ua = allUris[i].toString();
-            if (ua === u2) {
-                fileRelations[u].push(u2);
-            } else if (ua === u3) {
-                fileRelations[u].push(u3);
+            if (ua === u2 || ua === u3) {
+                fileRelations[u].push({ 'uri': ua, 'linked': linked });
+                if (!fileRelations[ua]) {
+                    fileRelations[ua] = [];
+                }
+                fileRelations[ua].push({ 'uri': u, 'linked': linked });
             }
         }
     }
 }
 
-/* parse an assembly file, find all labels, build up fileRelation lists */
+var poolRelationsRecursive = function(u, res)
+{
+    if(fileRelations[u]) {
+        for(var i in fileRelations[u]) {
+            var df = fileRelations[u][i].uri;
+            //if(df === u) continue;
+
+            found = false;
+            for(var k in res) {
+                if(res[k].uri === df) {
+                    found = true;
+                    break;
+                }
+            }
+            if(!found) {
+                res.push(fileRelations[u][i]);
+                poolRelationsRecursive(df, res);
+            }
+        }
+    }
+
+    return res;
+}
+
+var poolRelations = function()
+{
+    filepools = {};
+    for(var u in fileRelations) {
+        filepools[u] = poolRelationsRecursive(u, []);
+    }
+}
+
+/* parse an assembly file, find all labels, build up fileRelation list */
 var parseAssemblyDocument = function (document) {
 
     var u = document.uri.toString();
@@ -3948,11 +3984,13 @@ var parseAssemblyDocument = function (document) {
 
         if (splitted.parts[0].length > 0) {
             label = splitted.parts[0];
+            var isext = (splitted.parts[1].toLowerCase() === 'ext');
+            var isent = (splitted.parts[1].toLowerCase() === 'ent');
             var r = new vscode.Range(new vscode.Position(i, 0), new vscode.Position(i, label.length));
             if (!workspaceLabels[u]) {
                 workspaceLabels[u] = {};
             }
-            workspaceLabels[u][label] = { 'range': r, 'document': document };
+            workspaceLabels[u][label] = { 'range': r, 'document': document, 'isext': isext, 'isent': isent };
         }
     }
 }
@@ -3967,8 +4005,6 @@ var parseForReferences = function (document, label, includedef) {
         if (splitted === null) {
             continue;
         }
-
-        testAndAddFileRelation(document, splitted);
 
         var lr = findLabelReferenceInSplitted(document, i, splitted, label, includedef);
         for (var j in lr) {
@@ -4059,18 +4095,23 @@ var getAllLabelDefinitionsForDocument = function (mydocument) {
                     parseAssemblyDocument(doc);
                 });
 
+                poolRelations();
+
                 //gather all labels of all files that our file has relations to
                 var labels = {};
-                for (var i in fileRelations) {
-                    if (fileRelations[i].includes(u)) {
-                        for (var j in fileRelations[i]) {
-                            var df = fileRelations[i][j];
-                            if (workspaceLabels[df]) {
-                                for (var label in workspaceLabels[df]) {
-                                    labels[label] = workspaceLabels[df][label];
-                                };
+                for (var i in filepools[u]) {
+                    var df = filepools[u][i].uri;
+                    if (workspaceLabels[df]) {
+                        for (var label in workspaceLabels[df]) {
+                            if (!workspaceLabels[df][label]['isext']
+                                &&
+                                (u === df || typeof labels[label] === 'undefined')
+                            ) {
+                                //only definitions of labels, not external references
+                                //and only if we don't have it yet or it is "our" file
+                                labels[label] = workspaceLabels[df][label];
                             }
-                        }
+                        };
                     }
                 }
 
@@ -4099,7 +4140,17 @@ var getAllLabelDefinitionsForWorkspace = function () {
                     parseAssemblyDocument(doc);
                 });
 
-                myResolve(workspaceLabels);
+                //filter out ext labels
+                var filteredWorkspaceLabels = {};
+                for (var u in workspaceLabels) {
+                    for (var label in workspaceLabels[u]) {
+                        if (!workspaceLabels[u]['isext']) {
+                            filteredWorkspaceLabels[u][label] = workspaceLabels[u][label];
+                        }
+                    }
+                }
+
+                myResolve(filteredWorkspaceLabels);
             });
         });
     });
@@ -4114,6 +4165,7 @@ var getLabelReferences = function (mydocument, label, includedef) {
 
         labelReferences = {};
         fileRelations = {};
+        workspaceLabels = {};
 
         //all assembler and macro files in workspace
         vscode.workspace.findFiles(findfilesglob).then((uris) => {
@@ -4123,20 +4175,43 @@ var getLabelReferences = function (mydocument, label, includedef) {
             });
             Promise.all(proms).then((docs) => {
                 docs.forEach((doc) => {
+                    parseAssemblyDocument(doc);
                     parseForReferences(doc, label, includedef);
                 });
 
+                poolRelations();
+
+                //find the definition of our label
+                var includeRefsFromLinked = false;
+                for (var i in filepools[u]) {
+
+                    if (!filepools[u][i].linked) {
+                        var df = filepools[u][i].uri;
+                        if (typeof workspaceLabels[df] !== 'undefined'
+                            && typeof workspaceLabels[df][label] !== 'undefined'
+                            && (workspaceLabels[df][label].isext || workspaceLabels[df][label].isent)
+                        ) {
+                            //this means that our label is defined in another ASM linked
+                            //file, so we have to also include all label references
+                            //from files that are linked via ASM
+                            includeRefsFromLinked = true;
+                            break;
+                        }
+                    }
+                }
+
                 //gather all label references of all files that our file has relations to
                 var refs = [];
-                var filesadded = [];
-                for (var i in fileRelations) {
-                    if (fileRelations[i].includes(u) && !filesadded.includes(u)) {
-                        filesadded.push(u);
-                        for (var j in fileRelations[i]) {
-                            var df = fileRelations[i][j];
-                            if (labelReferences[df]) {
-                                refs = refs.concat(labelReferences[df]);
-                            }
+                for (var i in filepools[u]) {
+                    var df = filepools[u][i].uri;
+
+                    if (labelReferences[df]) {
+                        if (!filepools[u][i].linked) {
+                            //"put": include all references
+                            refs = refs.concat(labelReferences[df]);
+                        } else if (includeRefsFromLinked) {
+                            //"asm": include only EXT/ENT labels
+                            refs = refs.concat(labelReferences[df]);
                         }
                     }
                 }

--- a/syntaxes/65816.tmLanguage
+++ b/syntaxes/65816.tmLanguage
@@ -153,7 +153,7 @@
 			<key>comment</key>
 			<string>Mnemonics</string>
 			<key>match</key>
-			<string>\b(adc|and|asl|bcc|bcs|beq|bit|bmi|bne|bpl|bra|brk|brl|bvc|bvs|clc|cld|cli|clv|cmp|cpx|cpy|cop|dc|dec|dex|dey|eor|inc|inx|iny|jmp|jml|jsr|jsl|lda|ldx|ldy|lsr|mvn|mvp|nop|ora|pea|pei|per|pha|phb|phd|phk|php|phx|phy|pla|plb|pld|plp|plx|ply|rep|rol|ror|rti|rts|rtl|sbc|sec|sed|sei|sep|sta|stx|sty|stp|stz|tax|tay|tcd|tcs|tdc|tdc|tdx|txa|txs|txy|tya|tyx|trb|tsb|wai|wdm|xba|xce|ADC|AND|ASL|BCC|BCS|BEQ|BIT|BMI|BNE|BPL|BRA|BRK|BRL|BVC|BVS|CLC|CLD|CLI|CLV|CMP|CPX|CPY|COP|DC|DEC|DEX|DEY|EOR|INC|INX|INY|JMP|JML|JSR|JSL|LDA|LDX|LDY|LSR|MVN|MVP|NOP|ORA|PEA|PEI|PER|PHA|PHB|PHD|PHK|PHP|PHX|PHY|PLA|PLB|PLD|PLP|PLX|PLY|REP|ROL|ROR|RTI|RTS|RTL|SBC|SEC|SED|SEI|SEP|STA|STX|STY|STP|STZ|TAX|TAY|TCD|TCS|TDC|TDC|TDX|TXA|TXS|TXY|TYA|TYX|TRB|TSB|WAI|WDM|XBA|XCE)(.[b|w|v])?\b</string>
+			<string>\b(adc|and|asl|bcc|bcs|beq|bit|bmi|bne|bpl|bra|brk|brl|bvc|bvs|clc|cld|cli|clv|cmp|cpx|cpy|cop|dc|dec|dex|dey|eor|inc|inx|iny|jmp|jml|jsr|jsl|lda|ldx|ldy|lsr|mvn|mvp|nop|ora|pea|pei|per|pha|phb|phd|phk|php|phx|phy|pla|plb|pld|plp|plx|ply|rep|rol|ror|rti|rts|rtl|sbc|sec|sed|sei|sep|sta|stx|sty|stp|stz|tax|tay|tcd|tcs|tdc|tdc|tdx|txa|txs|txy|tya|tyx|trb|tsb|tsc|wai|wdm|xba|xce|ADC|AND|ASL|BCC|BCS|BEQ|BIT|BMI|BNE|BPL|BRA|BRK|BRL|BVC|BVS|CLC|CLD|CLI|CLV|CMP|CPX|CPY|COP|DC|DEC|DEX|DEY|EOR|INC|INX|INY|JMP|JML|JSR|JSL|LDA|LDX|LDY|LSR|MVN|MVP|NOP|ORA|PEA|PEI|PER|PHA|PHB|PHD|PHK|PHP|PHX|PHY|PLA|PLB|PLD|PLP|PLX|PLY|REP|ROL|ROR|RTI|RTS|RTL|SBC|SEC|SED|SEI|SEP|STA|STX|STY|STP|STZ|TAX|TAY|TCD|TCS|TDC|TDC|TDX|TXA|TXS|TXY|TYA|TYX|TRB|TSC|TSB|WAI|WDM|XBA|XCE)(.[b|w|v])?\b</string>
 			<key>name</key>
 			<string>keyword.mnemonic</string>
 		</dict>


### PR DESCRIPTION
This will support ASM, ENT and EXT Merlin32 statments.

[vscode_segmenttest.zip](https://github.com/user-attachments/files/21336364/vscode_segmenttest.zip)

To test, unpack the archive.
The main.s links other files via ASM, which in turn use PUT statements to include further files.

Test with go to definition/show references. All labels should be found correctly.